### PR TITLE
Consistent use of physical units & avoiding hard-coded arguments

### DIFF
--- a/oggm-edu/flowline_model.ipynb
+++ b/oggm-edu/flowline_model.ipynb
@@ -88,8 +88,8 @@
     "# define horizontal resolution of the model:\n",
     "# nx: number of grid points\n",
     "# map_dx: grid point spacing in meters\n",
-    "nx = 200\n",
-    "map_dx = 100"
+    "nx = 400\n",
+    "map_dx = 50"
    ]
   },
   {
@@ -147,8 +147,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The units of widths is in \"grid points\", i.e. 3 grid points = 300 m in our case\n",
-    "widths = np.zeros(nx) + 3.\n",
+    "initial_width = 300 #width in meters\n",
+    "# Now describe the widths in \"grid points\" for the model, based on grid point spacing map_dx\n",
+    "widths = np.zeros(nx) + initial_width/map_dx\n",
     "# Define our bed\n",
     "init_flowline = RectangularBedFlowline(surface_h=surface_h, bed_h=bed_h, widths=widths, map_dx=map_dx)"
    ]
@@ -192,7 +193,9 @@
    "outputs": [],
    "source": [
     "# ELA at 3000m a.s.l., gradient 4 mm m-1\n",
-    "mb_model = LinearMassBalance(3000, grad=4)"
+    "ELA = 3000 #equilibrium line altitude in meters above sea level\n",
+    "altgrad = 4 #altitude gradient in mm/m\n",
+    "mb_model = LinearMassBalance(ELA, grad=altgrad)"
    ]
   },
   {
@@ -379,7 +382,7 @@
    "metadata": {},
    "source": [
     "However, it is important to note, that the model will not calculate back in time.\n",
-    "Once calculated for 500 years, the model will not run again for 450 years and remains at 500 years."
+    "Once calculated for 500 years, the model will not run again for 450 years and remains at 500 years.  Try running the cell below.  Does the output match what you expected?"
    ]
   },
   {
@@ -397,7 +400,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that in order to store some intermediate steps of the evolution of the glacier, it might be useful to make a loop:"
+    "It might be useful to store some intermediate steps of the evolution of the glacier.  We make a loop so that the model reports to us several times."
    ]
   },
   {
@@ -490,12 +493,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# We define the widths as before:\n",
-    "widths = np.zeros(nx) + 3.\n",
-    "# But we now make our glacier 600 m wide for the first grid points:\n",
-    "widths[0:15] = 6\n",
+    "# We copy the widths we defined before\n",
+    "wider_widths = widths\n",
+    "# But we now make our glacier 600 m wide at the top:\n",
+    "new_width = 600 #meters\n",
+    "# Convert the width in meters to width in \"grid units\", like before, and rewrite the first few points\n",
+    "wider_widths[0:15] = new_width/map_dx\n",
     "# Define our new bed\n",
-    "wider_flowline = RectangularBedFlowline(surface_h=surface_h, bed_h=bed_h, widths=widths, map_dx=map_dx)"
+    "wider_flowline = RectangularBedFlowline(surface_h=surface_h, bed_h=bed_h, widths=wider_widths, map_dx=map_dx)"
    ]
   },
   {
@@ -591,7 +596,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/oggm-edu/flowline_model.ipynb
+++ b/oggm-edu/flowline_model.ipynb
@@ -88,8 +88,8 @@
     "# define horizontal resolution of the model:\n",
     "# nx: number of grid points\n",
     "# map_dx: grid point spacing in meters\n",
-    "nx = 400\n",
-    "map_dx = 50"
+    "nx = 200\n",
+    "map_dx = 100"
    ]
   },
   {
@@ -494,7 +494,7 @@
    "outputs": [],
    "source": [
     "# We copy the widths we defined before\n",
-    "wider_widths = widths\n",
+    "wider_widths = np.copy(widths)\n",
     "# But we now make our glacier 600 m wide at the top:\n",
     "new_width = 600 #meters\n",
     "# Convert the width in meters to width in \"grid units\", like before, and rewrite the first few points\n",

--- a/oggm-edu/mass_balance_gradients.ipynb
+++ b/oggm-edu/mass_balance_gradients.ipynb
@@ -82,17 +82,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This is the bed rock, linearily decreasing from 3400m altitude to 1400m, in 200 steps\n",
-    "nx = 200\n",
-    "bed_h = np.linspace(3400, 1400, nx)\n",
+    "# define horizontal resolution of the model:\n",
+    "# nx: number of grid points\n",
+    "# map_dx: grid point spacing in meters\n",
+    "nx = 400\n",
+    "map_dx = 50"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define glacier top and bottom altitudes in meters\n",
+    "top = 3400\n",
+    "bottom = 1400"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is the bed rock, linearily decreasing from top altitude to bottom altitude, in nx steps\n",
+    "bed_h = np.linspace(top, bottom, nx)\n",
     "# At the begining, there is no glacier so our glacier surface is at the bed altitude\n",
     "surface_h = bed_h\n",
-    "# Let's set the model grid spacing to 100m \n",
-    "map_dx = 100\n",
     "# calculate the corresponding distance along the glacier (from the top)\n",
     "distance_along_glacier = np.linspace(0,nx, nx) *0.1 # in km \n",
-    "# The units of widths is in \"grid points\", i.e. 3 grid points = 300 m in our case\n",
-    "widths = np.zeros(nx) + 3.\n",
+    "# Define the glacier width as we did in flowline_model\n",
+    "initial_width = 300 #width in meters\n",
+    "# Now describe the widths in \"grid points\" for the model, based on grid point spacing map_dx\n",
+    "widths = np.zeros(nx) + initial_width/map_dx\n",
     "# Define our bed\n",
     "init_flowline = RectangularBedFlowline(surface_h=surface_h, bed_h=bed_h, widths=widths, map_dx=map_dx)"
    ]
@@ -113,9 +136,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Define the MBGs we want to compare: (we worked with grad=4 in the \n",
+    "# Define the MBGs we want to compare: (we worked with grad=4mm/m in the \n",
     "# glacier flowline modelling notebook)\n",
-    "# We will calculate models with the MBGs: 0.3, 4 and 15 (These numbers can be found for real glaciers.) \n",
+    "# We will calculate models with the MBGs: 0.3, 4 and 15 mm/m. These numbers can be found for real glaciers. \n",
     "grad = [0.3, 4, 15]\n",
     "# Define the time period for which the glacier should be calculated:\n",
     "years = 300"
@@ -185,7 +208,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the left graphic we see that higher gradients show shallower slopes. The model with the highest gradient (purple line) experiences the highest ablation and accumulation. Therefore it shows the longest und thickest glacier after the chosen amount of calculated years (compare the right graphic). As the models are all calculated the same time span we can conclude that a high gradient leads to faster growing of a glacier. What do you think: where do we find glaciers with high MBGs?\n",
+    "In the left graphic we see that higher gradients show shallower slopes. The model with the highest gradient (purple line) experiences the highest ablation and accumulation. Therefore it shows the longest and thickest glacier after the chosen amount of calculated years (compare the right graphic). As the models are all calculated the same time span we can conclude that a high gradient leads to faster growing of a glacier. \n",
+    "\n",
+    "What do you think: where do we find glaciers with high MBGs?\n",
     "\n",
     "You find a short explanation in this [paragraph](http://www.antarcticglaciers.org/modern-glaciers/introduction-glacier-mass-balance/#SECTION_3)."
    ]
@@ -309,7 +334,7 @@
     "models = []\n",
     "                               \n",
     "for k, gradient in enumerate(grad):\n",
-    "    a = LinearMassBalance(3000, grad=gradient)\n",
+    "    a = LinearMassBalance(ELA, grad=gradient)\n",
     "    mb_models.append(a)\n",
     "    # Calculation of the annual mass balance along the glacier profile\n",
     "    annual_mb.append(a.get_annual_mb(surface_h) * cfg.SEC_IN_YEAR)\n",
@@ -407,7 +432,8 @@
    "source": [
     "# First we change the mass balance model, ELA decreases \n",
     "# (what could this tell us about the climate?)\n",
-    "mb_model1 = LinearMassBalance(2800, grad=0.3)"
+    "new_ELA = 2800 #m\n",
+    "mb_model1 = LinearMassBalance(new_ELA, grad=0.3)"
    ]
   },
   {
@@ -466,8 +492,8 @@
    "outputs": [],
    "source": [
     "# change Ela\n",
-    "mb_model2 = LinearMassBalance(2800, grad=4)\n",
-    "mb_model3 = LinearMassBalance(2800, grad=15)\n",
+    "mb_model2 = LinearMassBalance(new_ELA, grad=4)\n",
+    "mb_model3 = LinearMassBalance(new_ELA, grad=15)\n",
     "# Calculate the response time in years\n",
     "models[1].run_until_equilibrium(rate=0.006)\n",
     "response_time_2, model2_eq = edu.response_time_vol(models[1], mb_model2)\n",
@@ -567,7 +593,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
**In flowline_model:** The previous flowline_model.ipynb used hard-coded widths in "grid point" units. If the user changed the grid point spacing map_dx, the hard-coded widths did not update (so their physical-unit values changed despite the user not changing them directly). This update adds a line for the user to define widths in physical units and automatically adjusts the width in grid units if map_dx changes.

Also revised to remove double-use of variable name "widths", introducing "wider_widths" instead, so that the notebook cells can be run multiple times and produce correct results.


**In mass_balance_gradients:** Some initialization aspects of mass_balance_gradients were slightly different in style from flowline_model. Changed so that students more easily see the parallel in the workflow.

Also added units to MBGs and corrected a typo.

Finally, for users not familiar with OGGM function calls, the use of unlabelled arguments could be confusing. Updated so that the user adjusts a single named variable to change ELA, and the notebook then implements that variable instead of a preset value to call OGGM mass balance functions.