### PR TITLE
correct typo

### DIFF
--- a/oggm-edu/accumulation_and_ablation.ipynb
+++ b/oggm-edu/accumulation_and_ablation.ipynb
@@ -512,7 +512,7 @@
     "weights[model.fls[-1].thick == 0] = 0\n",
     "# Compute and pront\n",
     "weighted_mb_we = np.average(annual_mb_we, weights=weights)\n",
-    "print('Glacier specific mass balance (approx): {:.1f} m w.e. yr^-1'.format(weighted_mb / 1000.))"
+    "print('Glacier specific mass balance (approx): {:.1f} m w.e. yr^-1'.format(weighted_mb_we / 1000.))"
    ]
   },
   {


### PR DESCRIPTION
Corrects a variable name error I introduced in @dfrisinghelli 's notebook
