### PR TITLE
explicitly use climate_monthly filenames

### DIFF
--- a/oggm-tuto/merging_glaciers.ipynb
+++ b/oggm-tuto/merging_glaciers.ipynb
@@ -186,7 +186,7 @@
    "outputs": [],
    "source": [
     "cfg.PARAMS['use_intersects'] = False\n",
-    "gdirs_merged = workflow.merge_glacier_tasks(gdirs, 'RGI60-11.02709', return_all=False)"
+    "gdirs_merged = workflow.merge_glacier_tasks(gdirs, 'RGI60-11.02709', return_all=False, filename='climate_monthly')"
    ]
   },
   {
@@ -257,7 +257,7 @@
     "ds_entity = utils.compile_run_output([montmine], path=False, filesuffix='_entity')\n",
     "\n",
     "# model the merged glacier and complile the output\n",
-    "tasks.run_constant_climate(gdirs_merged, nyears=years, output_filesuffix='_merged', temperature_bias=tbias)\n",
+    "tasks.run_constant_climate(gdirs_merged, nyears=years, output_filesuffix='_merged', temperature_bias=tbias, climate_filename='climate_monthly')\n",
     "ds_merged = utils.compile_run_output([gdirs_merged], path=False, filesuffix='_merged')"
    ]
   },
@@ -372,7 +372,8 @@
     "tmp_merged = FileModel(gdirs_merged.get_filepath('model_run', filesuffix='_merged'))\n",
     "tmp_merged.run_until(years)\n",
     "\n",
-    "tasks.run_constant_climate(gdirs_merged, nyears=years, output_filesuffix='_merged2', init_model_fls=tmp_merged.fls, temperature_bias=tbias)\n",
+    "tasks.run_constant_climate(gdirs_merged, nyears=years, output_filesuffix='_merged2', init_model_fls=tmp_merged.fls, temperature_bias=tbias,\n",
+    "                           climate_filename='climate_monthly')\n",
     "ds_merged2 = utils.compile_run_output([gdirs_merged], path=False, filesuffix='_merged2')\n"
    ]
   },
@@ -436,6 +437,13 @@
     "- return to the [OGGM documentation](https://docs.oggm.org)\n",
     "- explore other tutorials on the [OGGM-Edu](https://edu.oggm.org) platform."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
necessary cause the files are named 'climate_historical' in the code but 'climate_monthly' in the preprocessed directories right now.
This explicit keyword needs to be removed once the preprocessed directories are updated. But for the moment this is less invasive than implementing a workaround in OGGM.